### PR TITLE
Change stroage of old DOM element to use data as variable on the DOM element does not work.

### DIFF
--- a/double.js
+++ b/double.js
@@ -4,23 +4,17 @@
  * licensed under http://creativecommons.org/licenses/by/3.0
  * more on http://haggen.github.com/double
  */
-;(function($, undefined) {
-  $.fn['double'] = function() { 
-    if(!this._double) {
-      this._original = this.clone(true);
-      this._double   = this.clone(true);
-
-      this.replaceWith(this._double);
-    }
-
-    return this._double;
+(function( $ ){
+  $.fn.saveState = function() {  
+    return this.each(function() {
+      var $this = $(this);
+      $this.data( '_original', $this.clone(true) );
+    });
   };
-
-  $.fn.recall = function() {
-    if(this._double) {
-      this._double.replaceWith(this._original);
-      delete this._double;
-      return this;
-    }
+  $.fn.recallState = function() {
+  	return this.each(function() {
+      var $this = $(this);
+      $this.replaceWith( $this.data( '_original' ) );
+    });	
   };
-}(window.jQuery));
+})( jQuery );


### PR DESCRIPTION
I have made many changes.

The plugin was not working for me. First I fixed that by storing the cloned DOM element in data. The plugin then worked. I moved on to cleaning up the mixed function definition syntax.

Lastly I added support for chaining as this also did not work. Oh and I also reduced it to one clone as two was unnecessary and expensive.

Thanks
Simon
